### PR TITLE
BUG: Convert the metadata object into a dataframe

### DIFF
--- a/rhapsody/q2/_method.py
+++ b/rhapsody/q2/_method.py
@@ -24,6 +24,9 @@ def mmvec(microbes: biom.Table,
           learning_rate: float = 0.001,
           summary_interval: int = 60) -> (pd.DataFrame, OrdinationResults):
 
+    if metadata is not None:
+        metadata = metadata.to_dataframe()
+
     # Note: there are a couple of biom -> pandas conversions taking
     # place here.  This is currently done on purpose, since we
     # haven't figured out how to handle sparse matrix multiplication


### PR DESCRIPTION
When using the QIIME2 plugin, code expected a pandas dataframe but instead
received a qiime2.Metadata object.