### PR TITLE
Fix q2 missing error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,7 @@
 import re
 import ast
 from glob import glob
-from setuptools import setup
-
+from setuptools import find_packages, setup
 
 classes = """
     Development Status :: 2 - Pre-Alpha
@@ -49,7 +48,7 @@ setup(name='rhapsody',
       author_email="jamietmorton@gmail.com",
       maintainer="gneiss development team",
       maintainer_email="jamietmorton@gmail.com",
-      packages=['rhapsody'],
+      packages=find_packages(),
       scripts=glob('scripts/rhapsody'),
       install_requires=[
           'biom-format',


### PR DESCRIPTION
Solving error: ModuleNotFoundError: No module named 'rhapsody.q2'