### PR TITLE
ConditionalFormat transformer fixes

### DIFF
--- a/rhapsody/q2/_transformer.py
+++ b/rhapsody/q2/_transformer.py
@@ -7,7 +7,7 @@ from rhapsody.q2.plugin_setup import plugin
 @plugin.register_transformer
 def _1(ff: ConditionalFormat) -> pd.DataFrame:
     df = pd.read_csv(str(ff), sep='\t', comment='#', skip_blank_lines=True,
-                     header=True, dtype=object)
+                     header=0, index_col=0)
     return df
 
 


### PR DESCRIPTION
A few proposed changes:
1. ConditionalFormat only contains numeric values (correct?) so do not import as object
2. `header=True` is an invalid choice with the current version of pandas. Need to specify row.
3. specify `index_col`, otherwise feature IDs are not used as index.